### PR TITLE
create and activate a python venv during setup

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -19,3 +19,7 @@ echo "   - OVH_AI_ENDPOINTS_ACCESS_TOKEN: " $OVH_AI_ENDPOINTS_ACCESS_TOKEN
 echo "   - OLLAM_API_KEY: " $OLLAM_API_KEY
 echo "   - OVH_AI_ENDPOINTS_MODEL_URL: " $OVH_AI_ENDPOINTS_MODEL_URL
 echo "   - OVH_AI_ENDPOINTS_MODEL_NAME: " $OVH_AI_ENDPOINTS_MODEL_NAME
+
+# create and activate a python venv
+python3 -m venv .venv
+source .venv/bin/activate


### PR DESCRIPTION
when the user source the setup with the command `source ./setup_env.sh` it creates a venv for Python and activate it.